### PR TITLE
Use dynamic interpreter path in bash scripts

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Generates a new project based on the contents of this project.
 # Basically works by simply copying all files to a destination. Names will be replaced appropriately.

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 
 if [ "$#" -eq 4 ]; then

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 
 # Updates an existing project using the latest version of ktorbase.


### PR DESCRIPTION
Running `generate.sh` on NixOS results in errors related to the use of the static interpreter path `/bin/bash`. Using `/usr/bin/env bash` instead finds the bash interpreter on the users `PATH` and is consequently more portable.

Since this is a public template I thought others could benefit from this change as well. If you're using the static path intentionally just reject the PR :)